### PR TITLE
Docker file added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.10-slim
+
+# Set working directory
+WORKDIR /app
+
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# Set environment variable
+ENV PYTHONUNBUFFERED=1
+
+
+
+# Run the API
+CMD ["python", "scripts/main.py"]

--- a/README.md
+++ b/README.md
@@ -43,115 +43,26 @@ script_directory/  (project root)
 
 ---
 
-## 🚀 Setup & Installation
+## Running The Project With Docker
 
-1. **Clone the repo** and change into the project directory:
+1. **Clone the repo** and navigate into the project directory:
 
    ```bash
    git clone https://github.com/DanDumitruArdeleanu/Applied-ML-Group8.git
    cd Applied-ML-Group8
    ```
-
-2. **Create a virtual environment** and activate it:
-
-   ```bash
-   python -m venv .venv
-   source .venv/bin/activate      # macOS/Linux
-   # .\.venv\Scripts\activate   # Windows PowerShell
+2. **Download Docker Desktop**, from the following link:
+   ```
+   https://www.docker.com/products/docker-desktop/
    ```
 
-3. **Install required packages**:
-
-   ```bash
-   pip install --upgrade pip
-   pip install -r requirements.txt
+3. **Build The Docker Image**:
+   ```
+   docker build --shm-size=2g -t my-ml-app .
    ```
 
-4. **Downloading Postprocessed Data**:
-
-  Google Drive link: https://drive.google.com/file/d/1GdDcnN_wJkE4gFuO9UmRgk-pOfvx4_Kl/view?usp=drive_link
-   
-   ```bash
-   gdown --id 1GdDcnN_wJkE4gFuO9UmRgk-pOfvx4_Kl `
-       --output .\Data\postprocessed_data.zip    # Downloading with gdown in terminal
+4. **Run Docker**:
+   ```
+   docker run --shm-size=2g -p 8000:8000 my-ml-app
    ```
 
-  Extract the data from the .zip file and replace the postprocessed_data with the new folder
-
-  Delete the .zip file
-
----
-
-## 🛠️ Usage
-
-### 1. Data Preprocessing & Rendering
-
-* **Preprocess raw `.ply` meshes** and compute PCA features:
-
-  ```bash
-  python scripts/data_datapreprocessing.py
-  ```
-
-* **Generate rotated screenshots & normal maps**:
-
-  ```bash
-  python scripts/data_postprocessing.py
-  ```
-
-  Outputs are placed in:
-
-  ```bash
-  data/postprocessed_data/screenshots/obj_XX/
-  data/postprocessed_data/normals/obj_XX/
-  ```
-
-### 2. Hyperparameter Tuning & Model Export
-
-* **Run training with Keras-Tuner**:
-
-  ```bash
-  python scripts/train_model.py
-  ```
-
-  * Tuner outputs -> `hyperparameter_optimisation/kt_dense_norm_tuning/dense_norm_pred`
-  * Final models & hyperparameters -> `hyperparameter_optimisation/exported_dense_normal_model`
-
-* **Summarize trial scores** (extract\_models.py):
-
-  ```bash
-  python scripts/extract_models.py
-  ```
-
-  Produces `trial_scores.json` in the exported model directory.
-
-* **Generate validation predictions**: included at end of `train_model.py`, saved into:
-
-  ```bash
-  data/predicted_data/obj_XX/best_prediction/
-  data/predicted_data/obj_XX/worst_prediction/
-  ```
-
-### 3. Running the API Server
-
-1. **Start the server** (from project root):
-
-   ```bash
-   uvicorn scripts.main:app --reload
-   ```
-
-2. **Browse the API docs**:
-   Open your browser to:
-
-   ```
-   http://127.0.0.1:8000/docs
-   ```
-
-   Use the interactive docs to test the `/predict/` endpoint.
-
----
-
-## 🔧 Configuration
-
-All file and folder paths are managed centrally in `scripts/config.py`. Modify there if you need to relocate data or outputs.
-
----


### PR DESCRIPTION

First, install Docker Desktop and ensure WSL2 integration is enabled for your Ubuntu-22.04 distro via Docker Desktop settings under “Resources” > “WSL Integration.” Then, open your WSL terminal (Ubuntu-22.04) and navigate to your project directory using cd /mnt/c/Users/ozdep/Documents/api/Applied-ML-Group8. Make sure the Dockerfile and requirements.txt are present by running ls. Once inside the correct folder, build your Docker image using docker build --shm-size=2g -t my-ml-app . — the --shm-size=2g flag helps avoid memory errors with large Python packages. After the image is successfully built, you can run your app using docker run -it my-ml-app or expose a port (e.g., 8000) using docker run -p 8000:8000 my-ml-app if you're running a web server like FastAPI.